### PR TITLE
Layout and rendering improvements

### DIFF
--- a/content/posts/snakebytes-tuple.md
+++ b/content/posts/snakebytes-tuple.md
@@ -54,3 +54,5 @@ for e in tpl:
 ```
 
 In fact, the parentheses are entirely optional, except in the case of an empty tuple.
+
+{{< footnotes >}}

--- a/themes/WriteIt/assets/css/_core/_media.scss
+++ b/themes/WriteIt/assets/css/_core/_media.scss
@@ -31,6 +31,10 @@
     display: block;
   }
 
+  .sidenotes-footnotes {
+    display: block !important;
+  }
+
   .page {
     width: 80%;
   }

--- a/themes/WriteIt/assets/css/_custom.scss
+++ b/themes/WriteIt/assets/css/_custom.scss
@@ -14,3 +14,10 @@
   line-height: 110%;
   font-weight: 200;
 }
+
+.sidenotes-footnotes {
+  display: none;
+  font-size: .8rem;
+  line-height: 110%;
+  font-weight: 200;
+}

--- a/themes/WriteIt/layouts/shortcodes/code.html
+++ b/themes/WriteIt/layouts/shortcodes/code.html
@@ -1,0 +1,35 @@
+{{ $path := .Get 0 }}
+{{ $name := .Get 1 }}
+{{ $contents := readFile (printf "/%s" $path) }}
+
+<!--Extract the snippet from the file.-->
+{{ $regexp := replace `(?s:.*)#.*\^BEGIN\sNAME\n([.\s\S]*)\n\s+#.*\^END\sNAME(?s:.*)` "NAME" $name }}
+{{ $snippet := replaceRE $regexp "$1" $contents }}
+
+<!--Snippets may be nested.-->
+<!--Replace any nested snippet indicators.-->
+{{ $snippet := replaceRE `(\s+#.*\^BEGIN\s.*)` "" $snippet }}
+{{ $snippet := replaceRE `(\s+#.*\^END\s.*)` "" $snippet }}
+
+<!--Find the common indentation to remove.-->
+{{ $whitespacePrefixCountPerLine := slice }}
+
+{{ $lines := split (trim $snippet "\n") "\n" }}
+{{ range $lines }}
+    {{ if (hasPrefix . " ") }}
+        {{ $whitespacePrefix := len (index (findRE `\s+` .) 0) }}
+        {{ $whitespacePrefixCountPerLine = $whitespacePrefixCountPerLine | append $whitespacePrefix }}
+    {{ else }}
+        {{ $whitespacePrefixCountPerLine = $whitespacePrefixCountPerLine | append 0 }}
+    {{ end }}
+{{ end }}
+
+{{ $whitespaceCountToRemove := index (sort $whitespacePrefixCountPerLine) 0 }}
+{{ $removePrefix := (" " | strings.Repeat $whitespaceCountToRemove) }}
+
+<!--Print without common indentation.-->
+```python
+{{- range $lines }}
+{{ safeHTML (strings.TrimPrefix $removePrefix .) -}}
+{{- end }}
+```

--- a/themes/WriteIt/layouts/shortcodes/footnotes.html
+++ b/themes/WriteIt/layouts/shortcodes/footnotes.html
@@ -1,0 +1,8 @@
+<div class="sidenotes-footnotes">
+    <hr>
+    {{ range $num, $text := (.Page.Scratch.Get "sidenotes") }}
+    <sup>{{ $num }}</sup>
+    {{ safeHTML $text | markdownify }}
+    <br><br>
+    {{ end }}
+</div>

--- a/themes/WriteIt/layouts/shortcodes/sidenote.html
+++ b/themes/WriteIt/layouts/shortcodes/sidenote.html
@@ -1,7 +1,12 @@
-<sup>{{ add .Ordinal 1 }}</sup>
+{{ .Page.Scratch.Add "sidenoteCount" 1 }}
+
+{{ $sidenoteNumber := .Page.Scratch.Get "sidenoteCount" }}
+{{ .Page.Scratch.SetInMap "sidenotes" (print $sidenoteNumber) .Inner }}
+
+<sup>{{ $sidenoteNumber }}</sup>
 <span class="sidenote">
     <span style="font-weight: 900">
-        <sup>{{ add .Ordinal 1 }}</sup>
+        <sup>{{ $sidenoteNumber }}</sup>
     </span>
     <span class="sidenote-contents">{{ .Inner | markdownify }}</span>
 </span>


### PR DESCRIPTION
Introduce a shortcode for a Python code snippet. Render sidenotes as footnotes if the page becomes too narrow.